### PR TITLE
fzrepl: fzf v0.25.0 changed phony switch to disabled

### DIFF
--- a/fzrepl
+++ b/fzrepl
@@ -95,7 +95,7 @@ mapfile -t REPLY < <(
     --sync \
     --ansi \
     --height=100% \
-    --phony \
+    --disabled \
     --print-query \
     --query="$default_query" \
     ${FZREPL_FILE:+--history=$FZREPL_FILE} \


### PR DESCRIPTION
Relevant link on the renaming:  https://github.com/junegunn/fzf/blob/master/CHANGELOG.md#0250  
I'm also not sure about `--ansi` and `--sync`.  
`--ansi` does not seem to affect preview window coloring. It is only the called command that matters when it sends its output in colors or not.  
`--sync` does not seem to be doing anything here as we are not doing a multi-staged filtering?