### PR TITLE
Replace Google search script 'goog' with DuckDuckGo script 'ddgsearch'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,16 @@ Interactively move files. It was originally just an experiment to see what it wo
 
 runs stdin against programs like sed, awk, jq and shows the result in the preview window
 
-## [goog](goog)
+## [ddgsearch](ddgsearch)
 
-Google search from the command line. This is now broken since google deprecated the API I used and I have yet to update to the newer version..
+A wrapper around [ddgr](https://github.com/jarun/ddgr) to search the web using DuckDuckGo.
+Accepts all `ddgr` command line arguments. For example, to search Wikipedia for "hello world":
 
-*depends on `jq` and `curl`*
+```sh
+ddgsearch \!w hello world
+```
+
+*depends on `jq` and `ddgr`*
 
 ## [igr](igr)
 
@@ -78,7 +83,7 @@ List and connect to wifi networks
 
 Currently there's no installation script, but if you clone the repo you can easily symlink the scripts here with something like:
 
-``` sh
+```sh
 cd /path/to/repo/fzf-scripts
 find -maxdepth 1 -executable -type f -exec ln -s -t $HOME/.local/bin $PWD/fzf-scripts/{} \;
 ```
@@ -89,6 +94,8 @@ find -maxdepth 1 -executable -type f -exec ln -s -t $HOME/.local/bin $PWD/fzf-sc
 * [fzf-tab](https://github.com/Aloxaf/fzf-tab) - use fzf to tab-complete everything in your shell
 
 # Legal
+
+Copyright (C) 2023 Ronald Joe Record <ronaldrecord@gmail.com>
 Copyright (C) 2016 Daniel F Gray <DanielFGray@gmail.com>
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.

--- a/ddgsearch
+++ b/ddgsearch
@@ -27,6 +27,24 @@ has() {
   done
 }
 
+select_from() {
+  local o c cmd OPTARG OPTIND
+  cmd='command -v'
+  while getopts 'c:' o; do
+    case "$o" in
+      c) cmd="$OPTARG" ;;
+    esac
+  done
+  shift "$((OPTIND-1))"
+  for c; do
+    if $cmd "${c%% *}" &> /dev/null; then
+      echo "$c"
+      return 0
+    fi
+  done
+  return 1
+}
+
 openurl() {
   local url="$1"
   local browser
@@ -44,33 +62,15 @@ openurl() {
   $browser "$url"
 }
 
-# http://stackoverflow.com/a/10660730
-rawurlencode() {
-  local string="$*"
-  local strlen=${#string}
-  local encoded=""
-  for (( pos=0; pos < strlen; pos++ )); do
-    c="${string:$pos:1}"
-    case "$c" in
-      [-_.~a-zA-Z0-9])
-        o="$c" ;;
-      *)
-        printf -v o '%%%02x' "'$c"
-    esac
-    encoded+="${o}"
-  done
-  echo "${encoded}"
-}
-
-has -v curl jq fzf || die
+has -v ddgr jq fzf || die
 
 if [[ -z "$*" ]]; then
   die 'nothing to search for'
 fi
 
-response=$( curl -sfL "http://ajax.googleapis.com/ajax/services/search/web?v=1.0&rsz=8&q=$(rawurlencode "$*")" ) || die 'error connecting to google, check connection'
-json=$( jq -c '.["responseData"]["results"] | map("\(.unescapedUrl) \(.title) | \(.content)") | .[]' <<< "$response" ) || die 'error parsing results :('
-url=$( fzf -e --ansi --cycle --inline-info <\
+response=$( ddgr --json --noprompt --expand "$*" ) || die 'error connecting to DuckDuckGo, check connection'
+json=$( jq -c '. | map("\(.url) | \(.title) | \(.abstract)") | .[]' <<< "$response" ) || die 'error parsing results :('
+url=$( fzf -e --ansi --cycle --inline-info --select-1 <\
   <( sed -r 's/<[^>]*>//g; s/\\n//g; s/^\s*"//; s/",?$//' <<< "$json" ) |
   cut -d' ' -f1 )
 


### PR DESCRIPTION
The Google search script `goog` no longer works since Google no longer supports that API.

The `ddgsearch` script uses the DuckDuckGo search engine by invoking [ddgr](https://github.com/jarun/ddgr) and parsing the return with `jq`.

This PR replaces `goog` with `ddgsearch` and updates the README.