### PR TITLE
feat: support distro "flavors"

### DIFF
--- a/pkgsearch
+++ b/pkgsearch
@@ -147,7 +147,6 @@ if [[ -r /etc/os-release ]]; then
     }
   ' /etc/os-release)
   distro="${distro%% *}"
-  echo $distro
 fi
 
 case "$distro" in

--- a/pkgsearch
+++ b/pkgsearch
@@ -133,8 +133,21 @@ has -v fzf gawk || die
 request="$*"
 
 if [[ -r /etc/os-release ]]; then
-  distro=$(awk -F'=' '"NAME" == $1 { gsub("\"", "", $2); print tolower($2); }' /etc/os-release)
+  # Attempt to get ID_LIKE from os-release to capture the "flavor" of the distro
+  # If ID_LIKE is not available, defer to ID
+  # If ID is not available, defer to NAME
+  distro=$(awk -F= '
+    $1=="ID_LIKE" { gsub(/"/,"",$2); idlike=$2 }
+    $1=="ID"      { gsub(/"/,"",$2); id=$2 }
+    $1=="NAME"    { gsub(/"/,"",$2); name=$2 }
+    END {
+      if (idlike)      print tolower(idlike)
+      else if (id)     print tolower(id)
+      else if (name)   print tolower(name)
+    }
+  ' /etc/os-release)
   distro="${distro%% *}"
+  echo $distro
 fi
 
 case "$distro" in


### PR DESCRIPTION
Noticed on my Manjaro machine that it would not pick up the distro "flavor" (arch) because the `NAME` field in `/etc/os-release` was "Manjaro Linux".  

This patch modifies the `awk` script used to find the distro such that it will first attempt to use the `ID_LIKE` field to capture the "flavor", deferring to `ID` if `ID_LIKE` is not set. Finally, it will defer to `NAME` if `ID` is not set. This makes more sense to me, as `NAME` is meant to be a human legible field, and `ID` and `ID_LIKE` have standardized formats. A future feature could be more complex parsing of `ID_LIKE`, but for now expecting a single value seems like it should be fine. 

Below I'm including descriptions of the described fields from `man os-release` as justification for this change:

```
NAME=
    A string identifying the operating system, without a version component, and suitable for presentation to the user. If not set, a default of "NAME=Linux" may be used.

    Examples: "NAME=Fedora", "NAME="Debian GNU/Linux"".

ID=
    A lower-case string (no spaces or other characters outside of 0–9, a–z, ".", "_" and "-") identifying the operating system, excluding any version information and suitable for processing by scripts or
usage in generated filenames. If not set, a default of "ID=linux" may be used. Note that even though this string may not include characters that require shell quoting, quoting may nevertheless be
used.

Examples: "ID=fedora", "ID=debian".

ID_LIKE=
    A space-separated list of operating system identifiers in the same syntax as the ID= setting. It should list identifiers of operating systems that are closely related to the local operating system in
regards to packaging and programming interfaces, for example listing one or more OS identifiers the local OS is a derivative from. An OS should generally only list other OS identifiers it itself is a
derivative of, and not any OSes that are derived from it, though symmetric relationships are possible. Build scripts and similar should check this variable if they need to identify the local
operating system and the value of ID= is not recognized. Operating systems should be listed in order of how closely the local operating system relates to the listed ones, starting with the closest.
    This field is optional.

    Examples: for an operating system with "ID=centos", an assignment of "ID_LIKE="rhel fedora"" would be appropriate. For an operating system with "ID=ubuntu", an assignment of "ID_LIKE=debian" is
appropriate.
```
